### PR TITLE
Support argument for both hash and pdf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ $ scripts/sign.sh PDF_FILE [SEED] [ALGO]
 ```
 Note that `SEED` is necessary when initializing the first hash, and the default `ALGO`  is sha256 if not specified manually.
 
-To verify if two pdf files are in the same chain, you can use the command:
+To verify if the given inputs are in the same chain, you can use the command:
 ```shell
-$ scripts/verify.sh PDF_QUERY PDF_ANCHOR [ALGO] [RANGE]
+$ scripts/verify.sh INPUT_PDF ANCHOR [ALGO] [RANGE]
 ```
-Note that `ALGO` is sha256 and `RANGE` is 10 by default.
+Note that `ALGO` is sha256 and `RANGE` is 10 by default. 
+`INPUT_PDF` and `ANCHOR` can be either base64 encoded hash or pdf file.

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+
+if [ "${1}" == "-h" ]; then
+    echo -e "Usage: \n\tscripts/sign.sh file seed [algo]"
+    exit 0
+fi
 
 # Check if binaries exist
 if ! [ -x "hashchain" ]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+
+if [ "${1}" == "-h" ]; then
+    echo -e "Usage: \n\tscripts/verify.sh input_pdf anchor [algo] [range]"
+    exit 0
+fi
 
 if ! [ -x "hashchain" ]; then
     echo "hashchain not found, execute make first"
@@ -11,8 +16,24 @@ if ! [ -x "$(command -v exiftool)" ]; then
 fi
 
 CONFIG="scripts/.exiftool_config"
-QUERY=$(exiftool -config "${CONFIG}" -s -s -s -Hash "${1}") || exit 1
-ANCHOR=$(exiftool -config "${CONFIG}" -s -s -s -Hash "${2}") || exit 1
+# Determine if file exists or valid base64 encoded hash
+if [ -e "${1}" ]; then
+    QUERY=$(exiftool -config "${CONFIG}" -s -s -s -Hash "${1}") || exit 1
+else
+    TEST=$(echo "${1}" | base64 -d 2>&1 > /dev/null)
+    [ $? != 0 ] && echo "Either file not exist or invalid base64 encoded string" && exit 1
+    QUERY="${1}"
+fi
+
+# Determine if file exists or valid base64 encoded hash
+if [ -e "${2}" ]; then
+    ANCHOR=$(exiftool -config "${CONFIG}" -s -s -s -Hash "${2}")
+else
+    TEST=$(echo "${2}" | base64 -d 2>&1 > /dev/null)
+    [ $? != 0 ] && echo "Either file not exist or invalid base64 encoded string" && exit 1
+    ANCHOR="${2}"
+fi
+
 [ -z ${3} ] && ALGO="sha256" || ALGO="${3}"
 [ -z ${4} ] && RANGE="10" || RANGE="${4}"
 


### PR DESCRIPTION
`scripts/verify.sh` originally receives two pdf files, this commit allows the argument to be either base64 encoded string or a pdf file.

The corresponding help message and README is also updated.