### PR TITLE
Reduce memory occupation in generating hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ $ make
 
 To create a hash chain, the arguments are:
 ```shell
-$ ./hashchain create ALGORITHM LENGTH SEED
+$ ./hashchain create -a ALGORITHM -l LENGTH SEED
 ```
 or 
 ```shell
-$ ./hashchain create ALGORITHM INDEX SIZE SEED
+$ ./hashchain create -a ALGORITHM -i INDEX -s SIZE SEED
 ```
 
 Simple example:
 ```shell
-$ ./hashchain create sha256 10 "my secret password"
+$ ./hashchain create -a sha256 -l 10 "my secret password"
 ```
 or equivalently,
 ```shell
-$ ./hashchain create sha256 1 10 "my secret password"
+$ ./hashchain create -a sha256 -i 1 -s 10 "my secret password"
 ```
 
 Alternatively, use built-in configurations:
@@ -65,15 +65,15 @@ fdW9x8zM1ztLel4upwt2qW8x4EFw/WEfBOiXBiyEcuk=
 
 To verify if two hashes are in the same chain, the arguments are:
 ```shell
-$ ./hashchain verify ALGORITHM QUERY ANCHOR [MAX_RANGE]
+$ ./hashchain verify -a ALGORITHM -q QUERY -n ANCHOR [-r MAX_RANGE]
 ```
 
 You can verify with the command:
 ```shell
-$ ./hashchain verify sha256 \
-              FBxCC4r4/u9oyBtuF3sets/MpX38yGPHkyL5rtaGB58= \
-              fdW9x8zM1ztLel4upwt2qW8x4EFw/WEfBOiXBiyEcuk= \
-              2
+$ ./hashchain verify -a sha256 \
+              -q FBxCC4r4/u9oyBtuF3sets/MpX38yGPHkyL5rtaGB58= \
+              -n fdW9x8zM1ztLel4upwt2qW8x4EFw/WEfBOiXBiyEcuk= \
+              -r 2
 success
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ To create a hash chain, the arguments are:
 ```shell
 $ ./hashchain create ALGORITHM LENGTH SEED
 ```
+or 
+```shell
+$ ./hashchain create ALGORITHM INDEX SIZE SEED
+```
 
 Simple example:
 ```shell
 $ ./hashchain create sha256 10 "my secret password"
+```
+or equivalently,
+```shell
+$ ./hashchain create sha256 1 10 "my secret password"
 ```
 
 Alternatively, use built-in configurations:

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -38,7 +38,7 @@ if [ -z "${HASH}" ]; then
         echo "Please specify a seed"
         exit 1
     fi
-    NEW_HASH=$(./hashchain create "${ALGO}" 1 "${SEED}")
+    NEW_HASH=$(./hashchain create -a "${ALGO}" -l 1 "${SEED}")
     echo "New hash: ${NEW_HASH}"
 else 
     NEW_HASH=$(echo -n "${HASH}" | \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,4 +37,4 @@ fi
 [ -z ${3} ] && ALGO="sha256" || ALGO="${3}"
 [ -z ${4} ] && RANGE="10" || RANGE="${4}"
 
-./hashchain verify "${ALGO}" "${QUERY}" "${ANCHOR}" "${RANGE}"
+./hashchain verify -a "${ALGO}" -q "${QUERY}" -n "${ANCHOR}" -r "${RANGE}"


### PR DESCRIPTION
Fixes #5.

The original implementation stores the generated hash in seperated
memory regions, which may lead to program crash.

I'll print the hash immediately instead of saving the hashes.

Generating hash with indicating index is also supported now using
`./hashchain create ALGO OFFSET SIZE SEED` format.